### PR TITLE
Update previewCards to accept 'did'

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -214,7 +214,7 @@ def _renderQA(self,data,qfmt=None,afmt=None):
 
 
 # this is a modification of a function from anki/collection.py
-def previewCards(self, note, type=0):
+def previewCards(self, note, type=0, did=None):
     existingTemplates = {c.template()[u'name'] : c for c in note.cards()}
     if type == 0:
         cms = self.findTemplates(note)
@@ -229,7 +229,7 @@ def previewCards(self, note, type=0):
         if template[u'name'] in existingTemplates:
             card = existingTemplates[template[u'name']]
         else:
-            card = self._newCard(note, template, 1, flush=False)
+            card = self._newCard(note, template, 1, flush=False, did=did)
         cards.append(card)
     return cards
 

--- a/__init__.py
+++ b/__init__.py
@@ -229,7 +229,10 @@ def previewCards(self, note, type=0, did=None):
         if template[u'name'] in existingTemplates:
             card = existingTemplates[template[u'name']]
         else:
-            card = self._newCard(note, template, 1, flush=False, did=did)
+            if packaging.version.parse(anki.version) < packaging.version.parse("2.1.9"):
+                card = self._newCard(note, template, 1, flush=False)
+            else:
+                card = self._newCard(note, template, 1, flush=False, did=did)
         cards.append(card)
     return cards
 


### PR DESCRIPTION
so that opening card templates will work again


Trying to open the card templates makes this error
```
Anki 2.1.9 (ae67c976) Python 3.6.7 Qt 5.12.1 PyQt 5.11.3
Platform: Windows 10
Flags: frz=True ao=True sv=2

Caught exception:
  File "aqt\webview.py", line 300, in handler
  File "aqt\editor.py", line 350, in <lambda>
  File "aqt\editor.py", line 238, in _onCardLayout
  File "<decorator-gen-60>", line 2, in __init__
  File "anki\hooks.py", line 74, in decorator_wrapper
  File "anki\hooks.py", line 65, in repl
  File "<decorator-gen-2>", line 2, in __init__
  File "anki\hooks.py", line 74, in decorator_wrapper
  File "anki\hooks.py", line 65, in repl
  File "aqt\clayout.py", line 55, in __init__
  File "aqt\clayout.py", line 67, in redraw
<class 'TypeError'>: previewCards() got an unexpected keyword argument 'did'
```
Offending line:
```
addons21\744725736\__init__.py
	Line 217: def previewCards(self, note, type=0):
```
Related to:
https://github.com/dae/anki/commit/d8f059b570a8f2e99348a8b6c2b521f46bf141ef
Line should read:
```
def previewCards(self, note, type=0, did=None):
```